### PR TITLE
[HB-4442] Using GitHub-Hosted Runners

### DIFF
--- a/.github/workflows/helium-unity.yml
+++ b/.github/workflows/helium-unity.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   compile:
     name: Compile Android Bridge
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout Branch
@@ -73,7 +73,7 @@ jobs:
 
   tests:
     name: Unity Actions & Unit Testing
-    runs-on: cb-office-mac-intel-1
+    runs-on: macos-latest
     needs: compile
 
     env:


### PR DESCRIPTION
# Description

Now that we are open source we should use GitHub- Hosted Runners. This makes the job take a bit longer, but that it's ok.