### PR TITLE
[HB-4541] Add a Slack Notification to #helium-ci Channel for Github Workflow Failures

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,33 @@
+name: Notify Slack
+
+on:
+  # This workflow will be triggered by the following workflows
+  workflow_run:
+    # Workflows must match the `name: ` field exactly.
+    workflows:
+      - Helium Unity SDK      
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    runs-on: [self-hosted]
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      # Usage of the Slack webhook url, requires that we use the `payload` parameter.
+      # The schema for the `SLACK_NOTIFY_HELIUM_UNITY_SDK_WEBHOOK` webhook is:
+      # {
+      #   "text": "Example text",
+      #   "run_id": "Example text",
+      #   "workflow_url": "Example text"
+      # }
+      - uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "run_id": ${{ github.event.workflow_run.id }},
+              "text": "🚨 Workflow '${{ github.event.workflow_run.name }}' failed 🚨",
+              "workflow_url": "https://github.com/ChartBoost/helium-unity-sdk/actions/runs/${{ github.event.workflow_run.id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_HELIUM_UNITY_SDK_WEBHOOK }}


### PR DESCRIPTION
Adds a slack notification when `Helium Unity SDK` workflow fails
